### PR TITLE
chore(spring-boot): update version and make it standalone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,16 +6,16 @@
 	<parent>
 		<groupId>org.cibseven</groupId>
 		<artifactId>release-parent</artifactId>
-		<version>1.1.0</version>
+		<version>1.2.0</version>
 	</parent>
 
 	<groupId>org.cibseven.examples.springboot</groupId>
 	<artifactId>cibseven-application</artifactId>
-	<version>2.0.0</version>
+	<version>2.1.0-SNAPSHOT</version>
 
 	<properties>
 		<springBoot.version>3.4.4</springBoot.version>
-		<spring.version>6.2.5</spring.version>
+		<spring.version>6.1.15</spring.version>
 	</properties>
 
 	<dependencyManagement>
@@ -49,7 +49,7 @@
 			<groupId>org.cibseven.bpm.springboot</groupId>
 			<artifactId>cibseven-bpm-spring-boot-starter-rest</artifactId>
 		</dependency>
-		
+
 		<!-- Spring boot -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -62,5 +62,25 @@
 		</dependency>
 
 	</dependencies>
+
+    <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${springBoot.version}</version>
+        <configuration>
+          <layout>ZIP</layout>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+   </build>
 
 </project>


### PR DESCRIPTION
2.1.0-SNAPSHOT version needs to be standalone packaged due to Eclipse's NotFileFound exception at runtime